### PR TITLE
add - added codesniffer with moodle standart

### DIFF
--- a/.github/workflows/codesniffer.yml
+++ b/.github/workflows/codesniffer.yml
@@ -1,0 +1,32 @@
+name: codesniffer
+on:
+  push:
+    branches: [ "main", "staging" ]
+  pull_request:
+    branches: [ "main", "staging"  ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Set up Composer
+    - name: Set up Composer
+      run: |
+        composer global config minimum-stability dev
+        composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+        composer global require moodlehq/moodle-cs
+
+    # Add Composer global bin to PATH
+    - name: Add Composer global bin to PATH
+      run: echo "PATH=$HOME/.composer/vendor/bin:$PATH" >> $GITHUB_ENV
+
+    # Run PHP_CodeSniffer
+    - name: Run Code Sniffer
+      run: phpcs server/moodle/mod/livequiz/


### PR DESCRIPTION
This is a tool for making sure the pull requests follow the moodle standard.

This helps everyone follow the standard better and speeds up the review process.

We added an actions script that spins up an Ubuntu machine that sets up and runs code sniffer with moodle standard.