### PR TITLE
Add --- Participations relation between student and livequiz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,4 @@ phpcbf.bat
 adminer_router.php
 etag.txt
 cacert.pem
+server/moodle/mod/livequiz/node_modules

--- a/server/moodle/mod/livequiz/classes/models/participation.php
+++ b/server/moodle/mod/livequiz/classes/models/participation.php
@@ -16,8 +16,6 @@
 
 namespace mod_livequiz\models;
 
-defined('MOODLE_INTERNAL') || die();
-
 use stdClass;
 
 /**
@@ -29,7 +27,7 @@ use stdClass;
  * @package mod_livequiz
  * @copyright 2024 Software AAU
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */class Participation {
+ */class participation {
     /**
      * Participation id
      * @var $id

--- a/server/moodle/mod/livequiz/classes/models/participation.php
+++ b/server/moodle/mod/livequiz/classes/models/participation.php
@@ -1,0 +1,103 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace mod_livequiz\models;
+
+defined('MOODLE_INTERNAL') || die();
+
+use stdClass;
+
+/**
+ * Class Participation
+ *
+ * This class will handle interactions with the participation table in the database.
+ * It will handle the creation, retrieval, and updates of participation records.
+ *
+ * @package mod_livequiz
+ * @copyright 2024 Software AAU
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */class Participation {
+    /**
+     * Participation id
+     * @var $id
+     */
+    private $id;
+    /**
+     * @var $studentid
+     */
+    private $studentid;
+    /**
+     * @var $livequizid
+     */
+    private $livequizid;
+
+
+    /**
+     * Participation constructor.
+     *
+     * @param $studentid
+     * @param $livequizid
+     */
+    public function __construct($studentid, $livequizid) {
+        $this->studentid = $studentid;
+        $this->livequizid = $livequizid;
+    }
+    /**
+     * get_id
+     * @return int
+     */
+    public function get_id(): int {
+        return $this->id;
+    }
+    /**
+     * get_studentid
+     * @return int
+     */
+    public function get_studentid(): int {
+        return $this->studentid;
+    }
+    /**
+     * get_livequizid
+     * @return int
+     */
+    public function get_livequizid(): int {
+        return $this->livequizid;
+    }
+    /**
+     * set_id
+     * @param int $id
+     * @return void
+     */
+    public function set_id(int $id): void {
+        $this->id = $id;
+    }
+    /**
+     * set_studentid
+     * @param int $studentid
+     * @return void
+     */
+    public function set_studentid(int $studentid): void {
+        $this->studentid = $studentid;
+    }
+    /**
+     * set_livequizid
+     * @param int $livequizid
+     * @return void
+     */
+    public function set_livequizid(int $livequizid): void {
+        $this->livequizid = $livequizid;
+    }
+}

--- a/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
+++ b/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
@@ -20,8 +20,7 @@ use dml_exception;
 use dml_transaction_exception;
 
 /**
- * 'Static' class, do not instantiate.
- * Displays the livequiz view page.
+ * This class is responsible for handling the relationship between students and quizzes.
  * @package   mod_livequiz
  * @copyright 2024 Software AAU
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later

--- a/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
+++ b/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
@@ -48,9 +48,12 @@ class student_quiz_relation {
     public static function get_all_student_participation_for_quiz(int $quizid, int $studentid): array {
         global $DB;
         $participationrecords =
-            $DB->get_records('livequiz_quiz_student',
-            ['livequiz_id' => $quizid, 'student_id' => $studentid],
-            'id DESC', '*');
+            $DB->get_records(
+                'livequiz_quiz_student',
+                ['livequiz_id' => $quizid, 'student_id' => $studentid],
+                'id DESC',
+                '*'
+            );
         $participations = [];
         foreach ($participationrecords as $participation) {
             $participations[] = new participation($participation->student_id, $participation->livequiz_id);

--- a/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
+++ b/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
@@ -28,7 +28,7 @@ use dml_transaction_exception;
  */
 class student_quiz_relation {
     /**
-     * Append an answer to a question, given its id
+     * Append a student to a quiz, given both their ids.
      *
      * @param int $questionid
      * @param int $answerid
@@ -36,7 +36,7 @@ class student_quiz_relation {
      * @throws dml_exception
      * @throws dml_transaction_exception
      */
-    public static function append_student_to_quiz(int $quizid, int $studentid): int {
+    public static function insert_student_quiz_relation(int $quizid, int $studentid): int {
         global $DB;
         return $DB->insert_record('livequiz_quiz_student', ['livequiz_id' => $quizid, 'student_id' => $studentid], true);
     }

--- a/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
+++ b/server/moodle/mod/livequiz/classes/models/student_quiz_relation.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_livequiz\models;
+
+use dml_exception;
+use dml_transaction_exception;
+
+/**
+ * 'Static' class, do not instantiate.
+ * Displays the livequiz view page.
+ * @package   mod_livequiz
+ * @copyright 2024 Software AAU
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class student_quiz_relation {
+    /**
+     * Append an answer to a question, given its id
+     *
+     * @param int $questionid
+     * @param int $answerid
+     * @return void
+     * @throws dml_exception
+     * @throws dml_transaction_exception
+     */
+    public static function append_student_to_quiz(int $quizid, int $studentid): int {
+        global $DB;
+        return $DB->insert_record('livequiz_quiz_student', ['livequiz_id' => $quizid, 'student_id' => $studentid], true);
+    }
+    /**
+     * Get all participation the student has made for a quiz
+     * @param int $quizid
+     * @return void
+     */
+    public static function get_all_student_participation_for_quiz(int $quizid, int $studentid): array {
+        global $DB;
+        $participationrecords =
+            $DB->get_records('livequiz_quiz_student',
+            ['livequiz_id' => $quizid, 'student_id' => $studentid],
+            'id DESC', '*');
+        $participations = [];
+        foreach ($participationrecords as $participation) {
+            $participations[] = new participation($participation->student_id, $participation->livequiz_id);
+        }
+        return $participations;
+    }
+}

--- a/server/moodle/mod/livequiz/classes/services/livequiz_services.php
+++ b/server/moodle/mod/livequiz/classes/services/livequiz_services.php
@@ -184,7 +184,6 @@ class livequiz_services {
 
         $updatedanswerids = [];
 
-
         $existinganswersmap = [];
         foreach ($existinganswers as $existinganswer) {
             $existinganswersmap[$existinganswer->get_id()] = $existinganswer;
@@ -221,7 +220,7 @@ class livequiz_services {
         }
         return $questions;
     }
-  
+
     /**
      * Creates a new participation record in the database.
      * @param int $studentid
@@ -243,6 +242,7 @@ class livequiz_services {
             throw $e;
         }
         return $participation;
+    }
 
     /**
      * Gets answers from a student in a specific participation.

--- a/server/moodle/mod/livequiz/classes/services/livequiz_services.php
+++ b/server/moodle/mod/livequiz/classes/services/livequiz_services.php
@@ -226,13 +226,12 @@ class livequiz_services {
      * @return participation
      */
     public function new_participation(int $studentid, int $quizid): participation {
-        // Todo: Validate input data.
         // Add parcitipation using the model.
         global $DB;
         $transaction = $DB->start_delegated_transaction();
         $participation = new participation($studentid, $quizid);
         try {
-            $participation->set_id(student_quiz_relation::append_student_to_quiz($quizid, $studentid));
+            $participation->set_id(student_quiz_relation::insert_student_quiz_relation($quizid, $studentid));
 
             $transaction->allow_commit();
         } catch (dml_exception $e) {

--- a/server/moodle/mod/livequiz/classes/services/livequiz_services.php
+++ b/server/moodle/mod/livequiz/classes/services/livequiz_services.php
@@ -23,6 +23,7 @@ require_once(__DIR__ . '/../models/question.php');
 require_once(__DIR__ . '/../models/answer.php');
 require_once(__DIR__ . '/../models/questions_answers_relation.php');
 require_once(__DIR__ . '/../models/quiz_questions_relation.php');
+require_once(__DIR__ . '/../models/student_quiz_relation.php');
 
 use dml_exception;
 use dml_transaction_exception;
@@ -32,6 +33,8 @@ use mod_livequiz\models\livequiz;
 use mod_livequiz\models\question;
 use mod_livequiz\models\questions_answers_relation;
 use mod_livequiz\models\quiz_questions_relation;
+use mod_livequiz\models\participation;
+use mod_livequiz\models\student_quiz_relation;
 
 /**
  * Class livequiz_services
@@ -189,5 +192,28 @@ class livequiz_services {
             $question->add_answers($answers);
         }
         return $questions;
+    }
+    /**
+     * Creates a new participation record in the database.
+     * @param int $studentid
+     * @param int $quizid
+     * @throws dml_exception
+     * @return participation
+     */
+    public function new_participation(int $studentid, int $quizid): participation {
+        // Todo: Validate input data.
+        // Add parcitipation using the model.
+        global $DB;
+        $transaction = $DB->start_delegated_transaction();
+        $participation = new participation($studentid, $quizid);
+        try {
+            $participation->set_id(student_quiz_relation::append_student_to_quiz($quizid, $studentid));
+
+            $transaction->allow_commit();
+        } catch (dml_exception $e) {
+            $transaction->rollback($e);
+            throw $e;
+        }
+        return $participation;
     }
 }

--- a/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
@@ -30,18 +30,47 @@ use mod_livequiz\models\livequiz;
 use mod_livequiz\services\livequiz_services;
 use mod_livequiz\models\question;
 use mod_livequiz\models\answer;
+use mod_livequiz\models\participation;
+use mod_livequiz\models\student_quiz_relation;
 
 /**
  * Testing examples for LiveQuiz service.
  */
 final class livequiz_service_test extends \advanced_testcase {
     /**
-     * Set up the test environment.
+     * Create participation test data.
+     * @return array
+     */
+    protected function create_participation_data_for_test(): array {
+        return  $participationdata = [
+            'studentid' => 2,
+            'quizid' => 1,
+        ];
+    }
+
+    /**
+     * Setup before each test.
+     * @return void
      */
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
     }
 
+    /**
+     * Test of new_participation
+     * @covers \mod_livequiz\services\livequiz_services::new_participation
+     */
+    public function test_new_participation(): void {
+        $participationdata = $this->create_participation_data_for_test();
+        $service = livequiz_services::get_singleton_service_instance();
 
+        $actualstudentid = $participationdata['studentid'];
+        $acutalquizid = $participationdata['quizid'];
+
+        $participation = $service->new_participation($actualstudentid, $acutalquizid);
+        $this->assertInstanceOf(participation::class, $participation);
+        $this->assertEquals($participation->get_studentid(), $actualstudentid);
+        $this->assertEquals($participation->get_livequizid(), $acutalquizid);
+    }
 }

--- a/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
@@ -1,0 +1,47 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * LiveQuiz Service Test Class
+ *
+ * This class contains unit tests for the LiveQuiz service functionality.
+ *
+ * @package mod_livequiz
+ * @copyright 2024 Software AAU
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_livequiz;
+
+use dml_exception;
+use mod_livequiz\models\livequiz;
+use mod_livequiz\services\livequiz_services;
+use mod_livequiz\models\question;
+use mod_livequiz\models\answer;
+
+/**
+ * Testing examples for LiveQuiz service.
+ */
+final class livequiz_service_test extends \advanced_testcase {
+    /**
+     * Set up the test environment.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+
+}

--- a/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
@@ -107,7 +107,6 @@ final class livequiz_service_test extends \advanced_testcase {
         $explanation = "I don't know.";
 
         $question = new question($title, $description, $timelimit, $explanation);
-
         self::assertInstanceOf(question::class, $question);
         self::assertEqualsIgnoringCase($title, $question->get_title());
         self::assertEqualsIgnoringCase($description, $question->get_description());

--- a/server/moodle/mod/livequiz/tests/phpunit/student_quiz_relation_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/student_quiz_relation_test.php
@@ -1,0 +1,98 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * LiveQuiz Service Test Class
+ *
+ * This class contains unit tests for the LiveQuiz service functionality.
+ *
+ * @package mod_livequiz
+ * @copyright 2024 Software AAU
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace mod_livequiz;
+
+use mod_livequiz\models\student_quiz_relation;
+
+/**
+ * student_quiz_relation_test
+ */
+final class student_quiz_relation_test extends \advanced_testcase {
+    /**
+     * Create participation test data. Used in every test.
+     * @return array
+     */
+    protected function create_test_data(): array {
+        // We need a quiz to append the participation to.
+        $livequizdata = [
+            'name' => 'Test LiveQuiz',
+            'course' => 1,
+            'intro' => 'This is a test livequiz.',
+            'introformat' => 1,
+            'timecreated' => time(),
+            'timemodified' => time(),
+        ];
+
+        global $DB;
+        $livequizid = $DB->insert_record('livequiz', $livequizdata, true);
+        return  $participationdata = [
+            'studentid' => 2,
+            'quizid' => $livequizid,
+        ];
+    }
+    /**
+     * Setup before each test.
+     * @return void
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+        $data = $this->create_test_data();
+        $actual = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+    }
+    /**
+     * Test of test_append_student_to_quiz.
+     * It is impossible to assert the actual table id, since it changes every time.
+     * @covers \mod_livequiz\models\student_quiz_relation::append_student_to_quiz
+     * @return void
+     */
+    public function test_append_student_to_quiz(): void {
+        $data = $this->create_test_data();
+        $actual = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+
+        $this->assertIsNumeric($actual);
+        $this->assertGreaterThan(0, $actual);
+    }
+    /**
+     * Test of get_all_student_participation_for_quiz
+     * @covers \mod_livequiz\models\student_quiz_relation::get_all_student_participation_for_quiz
+     * @return void
+     */
+    public function test_get_all_student_participation_for_quiz(): void {
+        $data = $this->create_test_data();
+        $participation1 = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+        $participation2 = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+
+        $participation = student_quiz_relation::get_all_student_participation_for_quiz($data['quizid'], $data['studentid']);
+        $this->assertNotNull($participation[0]);
+        $this->assertEquals($participation[0]->get_studentid(), $data['studentid']);
+        $this->assertEquals($participation[0]->get_livequizid(), $data['quizid']);
+        $this->assertNotNull($participation[1]);
+        $this->assertEquals($participation[1]->get_studentid(), $data['studentid']);
+        $this->assertEquals($participation[1]->get_livequizid(), $data['quizid']);
+        $this->assertEquals($participation1 + 1, $participation2);
+    }
+}

--- a/server/moodle/mod/livequiz/tests/phpunit/student_quiz_relation_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/student_quiz_relation_test.php
@@ -61,7 +61,7 @@ final class student_quiz_relation_test extends \advanced_testcase {
         parent::setUp();
         $this->resetAfterTest(true);
         $data = $this->create_test_data();
-        $actual = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+        $actual = student_quiz_relation::insert_student_quiz_relation($data['quizid'], $data['studentid']);
     }
     /**
      * Test of test_append_student_to_quiz.
@@ -71,7 +71,7 @@ final class student_quiz_relation_test extends \advanced_testcase {
      */
     public function test_append_student_to_quiz(): void {
         $data = $this->create_test_data();
-        $actual = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+        $actual = student_quiz_relation::insert_student_quiz_relation($data['quizid'], $data['studentid']);
 
         $this->assertIsNumeric($actual);
         $this->assertGreaterThan(0, $actual);
@@ -83,8 +83,8 @@ final class student_quiz_relation_test extends \advanced_testcase {
      */
     public function test_get_all_student_participation_for_quiz(): void {
         $data = $this->create_test_data();
-        $participation1 = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
-        $participation2 = student_quiz_relation::append_student_to_quiz($data['quizid'], $data['studentid']);
+        $participation1 = student_quiz_relation::insert_student_quiz_relation($data['quizid'], $data['studentid']);
+        $participation2 = student_quiz_relation::insert_student_quiz_relation($data['quizid'], $data['studentid']);
 
         $participation = student_quiz_relation::get_all_student_participation_for_quiz($data['quizid'], $data['studentid']);
         $this->assertNotNull($participation[0]);

--- a/server/moodle/mod/livequiz/view.php
+++ b/server/moodle/mod/livequiz/view.php
@@ -24,7 +24,9 @@
 require_once('../../config.php');
 require_once($CFG->libdir . '/accesslib.php'); // Include the access library for context_module.
 
-global $OUTPUT, $PAGE, $DB;
+use mod_livequiz\services\livequiz_services;
+
+global $OUTPUT, $PAGE, $DB, $USER;
 
 
 $id = required_param('id', PARAM_INT); // Course module ID.
@@ -38,6 +40,10 @@ $PAGE->set_context($context); // Make sure to set the page context.
 $PAGE->set_url('/mod/livequiz/view.php', ['id' => $id]);
 $PAGE->set_title(get_string('modulename', 'mod_livequiz'));
 $PAGE->set_heading(get_string('modulename', 'mod_livequiz'));
+
+$livequizservice = livequiz_services::get_singleton_service_instance();
+// Create a new participation record in the database. NOTE: This might not be necesarry when reading from the session.
+$livequizservice->new_participation($USER->id, $instance->id);
 
 echo $OUTPUT->header();
 echo $OUTPUT->heading('This is the livequiz view page');

--- a/server/moodle/mod/livequiz/view.php
+++ b/server/moodle/mod/livequiz/view.php
@@ -26,7 +26,7 @@ require_once($CFG->libdir . '/accesslib.php'); // Include the access library for
 
 use mod_livequiz\services\livequiz_services;
 
-global $OUTPUT, $PAGE, $DB, $USER;
+global $OUTPUT, $PAGE, $DB;
 
 
 $id = required_param('id', PARAM_INT); // Course module ID.
@@ -40,10 +40,6 @@ $PAGE->set_context($context); // Make sure to set the page context.
 $PAGE->set_url('/mod/livequiz/view.php', ['id' => $id]);
 $PAGE->set_title(get_string('modulename', 'mod_livequiz'));
 $PAGE->set_heading(get_string('modulename', 'mod_livequiz'));
-
-$livequizservice = livequiz_services::get_singleton_service_instance();
-// Create a new participation record in the database. NOTE: This might not be necesarry when reading from the session.
-$livequizservice->new_participation($USER->id, $instance->id);
 
 echo $OUTPUT->header();
 echo $OUTPUT->heading('This is the livequiz view page');


### PR DESCRIPTION
# Description
Methods for inserting a participation into the database have been created

## What is added/changed/removed
- Created participation class in models folder
- Added function to add participation to the "participation" table(actually called livequiz_quiz_student in db)
- Added function to get all participations based on livequizid and studentid
- Added a service layer function new_participation which calls the participation db methods
- Tests of insertion and retrieval of a participation from the database
 

## Issue/fixes reference
Number: https://github.com/orgs/AAU-P5-Moodle/projects/2/views/1?pane=issue&itemId=85501729&issue=AAU-P5-Moodle%7Cmoodle-1%7C55

The functions are not called from the 'front-end' exactly. However, we have a way to call any function from the front-end prepared in our branch https://github.com/AAU-P5-Moodle/moodle-1/tree/Individual-Quiz-Runner-Session which will be merged later

## Testing
Just run the phpunit testing suite

# Checks
- [x] Updated / added tests for these changes
- [x] PHPunit locally passed
- [x] Codesniffer locally passed
- [ ] Behat locally passed - (THESE TESTS ARE NOT RELEVANT FOR THE PR)

