### PR TITLE
Fix-Spelling-Mistake-Upgrade.php

### DIFF
--- a/server/moodle/mod/livequiz/db/upgrade.php
+++ b/server/moodle/mod/livequiz/db/upgrade.php
@@ -271,7 +271,7 @@ function xmldb_livequiz_upgrade($oldversion) {
         $questionslecturertable = new xmldb_table('questions_lecturer');
         $tables[] = $questionslecturertable;
         if ($dbman->table_exists($questionslecturertable)) {
-            $dbman->rename_table($questionslecturertable, 'livequiz_quiestions_lecturer');
+            $dbman->rename_table($questionslecturertable, 'livequiz_questions_lecturer');
         }
 
         // Rename table students_answers to livequiz_students_answers and updated foreign key reftables accordingly.


### PR DESCRIPTION
There were a single spelling error in upgrade that named a table incorrectly, which creates errors, when you upgrade your database instead of installing it from new.

# Description
//Describe this PR

## What is added/changed/removed
Removed a single "i" from line 274 in upgrade.php

## Issue/fixes reference
This is a general fix and not directly related to any single issue

## Testing
No testing should be necessary. However please check your db tables and see if you have one called "mdl_livequiz_quiestions_lecturer", as you should then rename it manually to "mdl_livequiz_questions_lecturer"

# Checks
- [x] Updated / added tests for these changes
- [x] PHPunit locally passed
- [x] Codesniffer locally passed
- [x] Behat locally passed

