### PR TITLE
fixed delete question - relation not deleted

### DIFF
--- a/server/moodle/mod/livequiz/classes/models/livequiz_questions_lecturer_relation.php
+++ b/server/moodle/mod/livequiz/classes/models/livequiz_questions_lecturer_relation.php
@@ -87,7 +87,7 @@ class livequiz_questions_lecturer_relation {
 
     /**
      *
-     * Deletes  lecturer_questions_relation by the relation id
+     * Deletes  lecturer_questions_relation by the question id
      *
      *
      * @param int $id
@@ -96,8 +96,8 @@ class livequiz_questions_lecturer_relation {
      * @throws dml_transaction_exception
      *
      */
-    public static function delete_lecturer_questions_relation_by_id(int $id): void {
+    public static function delete_lecturer_questions_relation_by_question_id(int $id): void {
         global $DB;
-        $DB->delete_records('livequiz_questions_lecturer', ['id' => $id]);
+        $DB->delete_records('livequiz_questions_lecturer', ['question_id' => $id]);
     }
 }

--- a/server/moodle/mod/livequiz/classes/services/livequiz_services.php
+++ b/server/moodle/mod/livequiz/classes/services/livequiz_services.php
@@ -384,10 +384,10 @@ class livequiz_services {
         $answers = questions_answers_relation::get_answers_from_question($questionid);
         foreach ($answers as $answer) {
             $currentanswerid = $answer->get_id();
-            self::delete_answer($currentanswerid, $questionid);
+            self::delete_answer($currentanswerid);
         }
         quiz_questions_relation::delete_question_quiz_relation($questionid);
-        livequiz_questions_lecturer_relation::delete_lecturer_questions_relation_by_id($questionid);
+        livequiz_questions_lecturer_relation::delete_lecturer_questions_relation_by_question_id($questionid);
         question::delete_question($questionid);
     }
 

--- a/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
@@ -472,7 +472,7 @@ final class livequiz_service_test extends \advanced_testcase {
     }
 
     /**
-     * Test that deleting a question, with a relation, throws.
+     * Test that deleting a question, with a relation, throws an exception.
      *
      * @covers \mod_livequiz\services\livequiz_services::submit_quiz
      * @throws dml_exception
@@ -500,9 +500,11 @@ final class livequiz_service_test extends \advanced_testcase {
         array_shift($testquizsubmittedquestions);
         $testquizsubmitted->set_questions($testquizsubmittedquestions);
 
+        // This sets up the test to expect the exception later in the code.
         $this->expectException(dml_exception::class);
         $this->expectExceptionMessage('error/Cannot delete answer with participations');
 
+        // This is the actual test where the exception is thrown.
         $service->submit_quiz($testquizsubmitted, $lecturerid);
         $testquizresubmittedquestions = $testquizsubmitted->get_questions();
     }


### PR DESCRIPTION
# Description
//Describe this PR

## What is added/changed/removed
Deletion of questions properly deletes relations

## Issue/fixes reference
//Reference the issue related to this pull request

//Isses: https://github.com/orgs/AAU-P5-Moodle/projects/2/views/1

//If this pull request is not directly related to a github issue, please elaborate on what has been fixed and why

## Testing
//Please explain how to allow PR-reviewers and codeowners on how to test your added functionality

# Checks
- [ ] Updated / added tests for these changes
- [ ] PHPunit locally passed
- [ ] Codesniffer locally passed
- [ ] Behat locally passed

