### PR TITLE
Fixed Editing Of Activity Module

### DIFF
--- a/server/moodle/mod/livequiz/lib.php
+++ b/server/moodle/mod/livequiz/lib.php
@@ -51,8 +51,7 @@ function livequiz_update_instance(object $quizdata): bool {
     global $DB;
 
     $quizdata->timemodified = time();
-    // Uncomment the following line if needed.!
-    // $quizdata->id = $quizdata->instance;!
+    $quizdata->id = $quizdata->instance;
 
     $DB->update_record('livequiz', $quizdata);
 

--- a/server/moodle/mod/livequiz/tests/phpunit/lib_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/lib_test.php
@@ -15,12 +15,13 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * This is the test file
+ * Test of lib.php.
  * @package mod_livequiz
  * @copyright 2023
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 namespace mod_livequiz;
+use stdClass;
 /**
  * Testing examples!
  */
@@ -41,10 +42,9 @@ final class lib_test extends \advanced_testcase {
      * It should return false if the instance cannot be added.
      */
     public function test_livequiz_add_instance(): void {
-        require_once(__DIR__ . '/../../lib.php');
         global $DB;
 
-        $quizdata = new \stdClass(); // Create a new stdClass object (empty object).
+        $quizdata = new stdClass(); // Create a new stdClass object (empty object).
         $quizdata->name = 'Test Quiz';
         $quizdata->intro = 'This is a test quiz.';
 
@@ -66,18 +66,20 @@ final class lib_test extends \advanced_testcase {
      */
     public function test_livequiz_update_instance(): void {
         global $DB;
-
-        $quizdata = new \stdClass();
+        // Prepare the data.
+        $quizdata = new stdClass();
         $quizdata->name = 'Test Quiz';
         $quizdata->intro = 'This is a test quiz.';
-
         $id = livequiz_add_instance($quizdata);
-        $quizdata->id = $id;
+        $quizdata->instance = $id;
         $quizdata->name = 'Updated Test Quiz';
 
+        // Execute.
         $result = livequiz_update_instance($quizdata);
-        $this->assertTrue($result);
         $record = $DB->get_record('livequiz', ['id' => $id]);
+        
+        // Assert.
+        $this->assertTrue($result);
         $this->assertEquals('Updated Test Quiz', $record->name);
     }
 
@@ -93,7 +95,7 @@ final class lib_test extends \advanced_testcase {
     public function test_livequiz_delete_instance(): void {
         global $DB;
 
-        $quizdata = new \stdClass();
+        $quizdata = new stdClass();
         $quizdata->name = 'Test Quiz';
         $quizdata->intro = 'This is a test quiz.';
 

--- a/server/moodle/mod/livequiz/tests/phpunit/lib_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/lib_test.php
@@ -77,7 +77,6 @@ final class lib_test extends \advanced_testcase {
         // Execute.
         $result = livequiz_update_instance($quizdata);
         $record = $DB->get_record('livequiz', ['id' => $id]);
-        
         // Assert.
         $this->assertTrue($result);
         $this->assertEquals('Updated Test Quiz', $record->name);


### PR DESCRIPTION
# Description
You can now edit activity modules after their creation. 

## What is added/changed/removed

- Removed commented out code in the lib.php file, which was necessary

## Issue/fixes reference
https://github.com/AAU-P5-Moodle/moodle-1/issues/175

## Testing
- Create a quiz
- Try editing the quiz through the settings page
- Click save
- See that the changes are made

# Checks
- [ ] Updated / added tests for these changes
- [ ] PHPunit locally passed
- [ ] Codesniffer locally passed
- [ ] Behat locally passed

