### PR TITLE
FIX - Include existing questions in filter when importing

### DIFF
--- a/server/moodle/mod/livequiz/classes/external/reuse_question.php
+++ b/server/moodle/mod/livequiz/classes/external/reuse_question.php
@@ -65,13 +65,13 @@ class reuse_question extends external_api {
     public static function execute(int $quizid, array $questionids, int $lecturerid): array {
         self::validate_parameters(self::execute_parameters(), [
             'quizid' => $quizid,
-            'questionids' => $questionids, //These are id's of the questions to be reused, in the new livequiz.
+            'questionids' => $questionids, // These are id's of the questions to be reused, in the new livequiz.
             'lecturerid' => $lecturerid,
         ]);
         $services = livequiz_services::get_singleton_service_instance();
         try {
             $livequiz = $services->get_livequiz_instance($quizid);
-            $existingquestions = $livequiz->get_questions(); //These are the questions already present in the livequiz
+            $existingquestions = $livequiz->get_questions(); // These are the questions already present in the livequiz.
             $questionids = self::filter_unique_questions($questionids);
             $questionstoadd = [];
             foreach ($questionids as $id) {
@@ -128,7 +128,7 @@ class reuse_question extends external_api {
             $unique = true;
             foreach ($uniquequestions as $uniquequestion) {
                 // Check if the questions are identical.
-                if(self::is_identical_question($question, $uniquequestion)){
+                if (self::is_identical_question($question, $uniquequestion)) {
                     $unique = false;
                     break;
                 }
@@ -144,33 +144,42 @@ class reuse_question extends external_api {
         return $returningquestions; // Return the prepared questions.
     }
 
+    /**
+     * Checks if two questions are identical.
+     *
+     * @param question $question1 The first question to compare.
+     * @param question $question2 The second question to compare.
+     * @return bool True if the questions are identical, false otherwise.
+     */
     private static function is_identical_question(question $question1, question $question2): bool {
-        if( $question1->get_title() == $question2->get_title()
+        if (
+            $question1->get_title() == $question2->get_title()
             && $question1->get_description() == $question2->get_description()
             && $question1->get_timelimit() == $question2->get_timelimit()
             && $question1->get_explanation() == $question2->get_explanation()
-            && count($question1->get_answers()) == count($question2->get_answers())){
-                // If the questions are identical, then we check the answers to see if they are identical.
-                $identicalanswercount = 0;
-                foreach ($question1->get_answers() as $uniqueanswer) {
-                    foreach ($question2->get_answers() as $answer) {
-                        if (
-                            $answer->get_correct() == $uniqueanswer->get_correct()
-                            && $answer->get_description() == $uniqueanswer->get_description()
-                            && $answer->get_explanation() == $uniqueanswer->get_explanation()
-                        ) {
-                            $identicalanswercount++;
-                            // If there are as many identical answers as there are answers.
-                            // Then we won't include it in the list, as it is identical to another question.
-                            if ($identicalanswercount == count($question1->get_answers())) {
+            && count($question1->get_answers()) == count($question2->get_answers())
+        ) {
+            // If the questions are identical, then we check the answers to see if they are identical.
+            $identicalanswercount = 0;
+            foreach ($question1->get_answers() as $uniqueanswer) {
+                foreach ($question2->get_answers() as $answer) {
+                    if (
+                         $answer->get_correct() == $uniqueanswer->get_correct()
+                         && $answer->get_description() == $uniqueanswer->get_description()
+                         && $answer->get_explanation() == $uniqueanswer->get_explanation()
+                    ) {
+                        $identicalanswercount++;
+                        // If there are as many identical answers as there are answers.
+                        // Then we won't include it in the list, as it is identical to another question.
+                        if ($identicalanswercount == count($question1->get_answers())) {
                                 return true;
-                            }
                         }
                     }
                 }
-                return false; // If the questions are identical, but the answers are not, then we include it in the list.
-            } else {
-                return false;
             }
+                return false; // If the questions are identical, but the answers are not, then we include it in the list.
+        } else {
+                return false;
+        }
     }
 }


### PR DESCRIPTION
# Description
If you have a question in a quiz and try to import the same question again, it is not possible.

## What is added/changed/removed
- Filtering away questions already present in a livequiz

## Issue/fixes reference
https://github.com/AAU-P5-Moodle/moodle-1/issues/162

## Testing
- Create a quiz
- Create a question in this quiz
- Create another quiz
- In this quiz import the question you created previously
- This should work
- Now try to import the question again
- This should NOT work

# Checks
- [ ] Updated / added tests for these changes
- [ ] PHPunit locally passed
- [ ] Codesniffer locally passed
- [ ] Behat locally passed

