### PR TITLE
fix - PHPUnit and Behat to use 8.3 version

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -53,6 +53,7 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
+          php-version: '8.3'
           extensions: phar, iconv, mbstring, gd, intl, sodium, zip
           tools: composer
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -25,6 +25,7 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
+          php-version: '8.3'
           extensions: phar, iconv, mbstring, gd, intl, sodium, zip
           tools: composer
 


### PR DESCRIPTION
# Description
changed the PHP version from 8.4 to 8.3 so that our CLI can run again

![image](https://github.com/user-attachments/assets/df0bda4b-d31d-468d-b7ae-63dfc679ecf9)
The PHP version updated recently, It's still not LTS by the looks of it, so we changed the script to specify the previous version we used before.

## What is added/changed/removed
changed the PHP version from 8.4 to 8.3 so that our CLI can run again the previous change was automatic now we specify explicitly the version.

## Issue/fixes reference

## Testing
Should make CLI test to work

# Checks
- [ ] Updated / added tests for these changes
- [ ] PHPunit locally passed
- [ ] Codesniffer locally passed
- [ ] Behat locally passed

