### PR TITLE
Generel PHP code cleanup

### DIFF
--- a/server/moodle/mod/livequiz/classes/models/livequiz.php
+++ b/server/moodle/mod/livequiz/classes/models/livequiz.php
@@ -17,7 +17,8 @@
 namespace mod_livequiz\models;
 
 use dml_exception;
-use mysql_xdevapi\Exception;
+use InvalidArgumentException;
+use RuntimeException;
 use stdClass;
 
 /**
@@ -249,13 +250,13 @@ class livequiz {
             if ($question->get_id() === $questionid) {
                 // If we already found a question, it means that there are questions with duplicate id.
                 if ($questionwithid !== null) {
-                    throw new \RuntimeException("Something is wrong. Multiple questions found with id {$questionid}");
+                    throw new RuntimeException("Something is wrong. Multiple questions found with id {$questionid}");
                 }
                 $questionwithid = $question;
             }
         }
         if ($questionwithid === null) {
-            throw new \InvalidArgumentException("Could not find question with id {$questionid}");
+            throw new InvalidArgumentException("Could not find question with id {$questionid}");
         }
         return $questionwithid;
     }

--- a/server/moodle/mod/livequiz/classes/models/livequiz_quiz_lecturer_relation.php
+++ b/server/moodle/mod/livequiz/classes/models/livequiz_quiz_lecturer_relation.php
@@ -70,7 +70,7 @@ class livequiz_quiz_lecturer_relation {
      * @throws dml_transaction_exception
      *
      */
-    public static function check_lecturer_quiz_relation_exists(int $quizid, $lecturerid): bool {
+    public static function check_lecturer_quiz_relation_exists(int $quizid, int $lecturerid): bool {
         global $DB;
         return $DB->record_exists('livequiz_quiz_lecturer', ['lecturer_id' => $lecturerid, 'quiz_id' => $quizid]);
     }

--- a/server/moodle/mod/livequiz/classes/output/results_page.php
+++ b/server/moodle/mod/livequiz/classes/output/results_page.php
@@ -67,7 +67,6 @@ class results_page implements renderable, templatable {
         $data->isattempting = false; // This is the results page, so the user is not attempting the quiz.
         // Get the questions with their answers.
         $livequizservices = livequiz_services::get_singleton_service_instance();
-        $questions = $livequizservices->get_questions_with_answers($this->livequiz->get_id());
 
         // Get the student's answers for the participation.
         $participationanswerids = $livequizservices->get_answersids_from_student_in_participation(
@@ -80,7 +79,7 @@ class results_page implements renderable, templatable {
             ['id' => $this->cmid]
         ))->out(false);
 
-        // Prepare the questions data.
+        // Prepare the questions' data.
         foreach ($data->questions as $qindex => $question) {
             // Get the student's answer for this question.
             foreach ($question->answers as $aindex => $answer) {

--- a/server/moodle/mod/livequiz/classes/services/livequiz_services.php
+++ b/server/moodle/mod/livequiz/classes/services/livequiz_services.php
@@ -331,7 +331,6 @@ class livequiz_services {
      * @throws dml_exception
      */
     public function get_newest_participation_for_quiz(int $quizid, int $studentid): participation {
-        global $DB;
         $participations = student_quiz_relation::get_all_student_participation_for_quiz($quizid, $studentid);
         return $participations[0];
     }

--- a/server/moodle/mod/livequiz/db/upgrade.php
+++ b/server/moodle/mod/livequiz/db/upgrade.php
@@ -27,8 +27,10 @@
  *
  * @param $oldversion
  * @return true
+ * @throws ddl_exception
+ * @throws ddl_table_missing_exception
  */
-function xmldb_livequiz_upgrade($oldversion) {
+function xmldb_livequiz_upgrade($oldversion): bool {
     global $DB;
 
     $dbman = $DB->get_manager();

--- a/server/moodle/mod/livequiz/tests/phpunit/activitysetup_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/activitysetup_test.php
@@ -24,7 +24,10 @@
  */
 
 namespace mod_livequiz;
+use advanced_testcase;
+use coding_exception;
 use mod_livequiz_mod_form;
+use MoodleQuickForm;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -40,12 +43,13 @@ require_once($CFG->dirroot . '/mod/livequiz/mod_form.php');
  * @copyright  2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-final class activitysetup_test extends \advanced_testcase {
+final class activitysetup_test extends advanced_testcase {
     /**
      * Activity Setup Test function.
      * This function tests the setup of mod_form without assuming _form as a field.
      * It calls the definition function, standard_coursemodule_elements, and add_action_buttons.
      * @covers \mod_livequiz\activitysetup_test::test_mod_form_setup
+     * @throws coding_exception
      */
     public function test_mod_form_setup(): void {
         $this->resetAfterTest(true);
@@ -60,7 +64,7 @@ final class activitysetup_test extends \advanced_testcase {
             ->getMock();
 
         // Create an instance of MoodleQuickForm and inject it into the _form property using reflection.
-        $form = new \MoodleQuickForm('modform', 'POST', '', null, ['class' => 'mform'], true);
+        $form = new MoodleQuickForm('modform', 'POST', '', null, ['class' => 'mform'], true);
 
         $mock->set_form($form);
 

--- a/server/moodle/mod/livequiz/tests/phpunit/classtest/livequiz_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/classtest/livequiz_test.php
@@ -25,10 +25,11 @@
 namespace mod_livequiz;
 
 use advanced_testcase;
+use InvalidArgumentException;
 use mod_livequiz\models\question;
+use RuntimeException;
 use stdClass;
 use ReflectionException;
-use Exception;
 use function PHPUnit\Framework\assertEquals;
 
 
@@ -342,7 +343,7 @@ final class livequiz_test extends advanced_testcase {
 
 
         // Test invalid case: No question with the given ID.
-        $this->expectException(\InvalidArgumentException::class); // Expect an InvalidArgumentExceptionException to be thrown.
+        $this->expectException(InvalidArgumentException::class); // Expect an InvalidArgumentExceptionException to be thrown.
         $this->expectExceptionMessage("Could not find question with id 20");
         $livequiz->get_question_by_id(20); // This ID doesn't exist, should throw an exception.
 
@@ -355,7 +356,7 @@ final class livequiz_test extends advanced_testcase {
         $livequiz->add_question($mockquestion4);
 
         // Test invalid case: Multiple questions with the same ID.
-        $this->expectException(\RuntimeException::class); // Expect a RuntimeException to be thrown.
+        $this->expectException(RuntimeException::class); // Expect a RuntimeException to be thrown.
         $this->expectExceptionMessage("Something is wrong. Multiple questions found with id 1");
         $livequiz->get_question_by_id(1);
     }

--- a/server/moodle/mod/livequiz/tests/phpunit/externalclasstest/save_question_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/externalclasstest/save_question_test.php
@@ -25,11 +25,10 @@
 namespace mod_livequiz;
 
 use advanced_testcase;
-use dml_exception;
 use mod_livequiz\external\save_question;
-use mod_livequiz\models\livequiz;
 use mod_livequiz\models\question;
 use ReflectionClass;
+use ReflectionException;
 use function PHPUnit\Framework\assertEquals;
 
 /**
@@ -40,6 +39,7 @@ final class save_question_test extends advanced_testcase {
      * Test the save_question external function.
      * This function tests if a question can be saved to the database.
      * @covers      \mod_livequiz\external\save_question::new_question
+     * @throws ReflectionException
      */
     public function test_new_question(): void {
         $this->resetAfterTest();
@@ -77,9 +77,11 @@ final class save_question_test extends advanced_testcase {
         assertEquals($questiondata['answers'][1]['correct'], $answers[1]->get_correct());
         assertEquals($questiondata['answers'][1]['explanation'], $answers[1]->get_explanation());
     }
+
     /**
      * Allows calling of private function new_question
      * @covers      \mod_livequiz\external\save_question::new_question
+     * @throws ReflectionException
      */
     private static function call_new_question(array $questiondata): question {
         $class = new ReflectionClass(save_question::class);

--- a/server/moodle/mod/livequiz/tests/phpunit/lib_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/lib_test.php
@@ -21,10 +21,14 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 namespace mod_livequiz;
+use advanced_testcase;
+use dml_exception;
+use stdClass;
+
 /**
  * Testing examples!
  */
-final class lib_test extends \advanced_testcase {
+final class lib_test extends advanced_testcase {
     protected function setUp(): void {
         parent::setUp();
         $this->resetAfterTest(true);
@@ -39,12 +43,13 @@ final class lib_test extends \advanced_testcase {
      * It should return the ID of the new instance.
      * It should set the name and intro fields of the new instance.
      * It should return false if the instance cannot be added.
+     * @throws dml_exception
      */
     public function test_livequiz_add_instance(): void {
         require_once(__DIR__ . '/../../lib.php');
         global $DB;
 
-        $quizdata = new \stdClass(); // Create a new stdClass object (empty object).
+        $quizdata = new stdClass(); // Create a new stdClass object (empty object).
         $quizdata->name = 'Test Quiz';
         $quizdata->intro = 'This is a test quiz.';
 
@@ -63,11 +68,12 @@ final class lib_test extends \advanced_testcase {
      * This function should update an existing livequiz instance in the database.
      * It should return true if the instance is updated successfully.
      * It should return false if the instance cannot be updated.
+     * @throws dml_exception
      */
     public function test_livequiz_update_instance(): void {
         global $DB;
 
-        $quizdata = new \stdClass();
+        $quizdata = new stdClass();
         $quizdata->name = 'Test Quiz';
         $quizdata->intro = 'This is a test quiz.';
 
@@ -89,11 +95,12 @@ final class lib_test extends \advanced_testcase {
      * This function should delete an existing livequiz instance from the database.
      * It should return true if the instance is deleted successfully.
      * It should return false if the instance cannot be deleted.
+     * @throws dml_exception
      */
     public function test_livequiz_delete_instance(): void {
         global $DB;
 
-        $quizdata = new \stdClass();
+        $quizdata = new stdClass();
         $quizdata->name = 'Test Quiz';
         $quizdata->intro = 'This is a test quiz.';
 

--- a/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/livequiz_service_test.php
@@ -25,21 +25,22 @@
  */
 namespace mod_livequiz;
 
+use advanced_testcase;
 use dml_exception;
 use dml_transaction_exception;
+use Error;
 use mod_livequiz\models\livequiz;
 use mod_livequiz\models\student_answers_relation;
 use mod_livequiz\services\livequiz_services;
 use mod_livequiz\models\question;
 use mod_livequiz\models\answer;
 use mod_livequiz\models\participation;
-use mod_livequiz\models\student_quiz_relation;
 use PhpXmlRpc\Exception;
 
 /**
  * Testing examples for LiveQuiz service.
  */
-final class livequiz_service_test extends \advanced_testcase {
+final class livequiz_service_test extends advanced_testcase {
     /**
      * Create a LiveQuiz instance for testing.
      *
@@ -216,7 +217,6 @@ final class livequiz_service_test extends \advanced_testcase {
      *
      * @covers \mod_livequiz\models\answer::__construct
      * @return void
-     * @throws dml_exception
      */
     public function test_new_answer(): void {
         $title = 'Test question';
@@ -286,7 +286,7 @@ final class livequiz_service_test extends \advanced_testcase {
         self::assertEquals($getquiz['lecturer_id'], $lecturerid);
 
 
-        // The amount of questions remain the same.
+        // The amount of questions remains the same.
         $questionsresult = $livequizresult->get_questions();
         self::assertCount(count($questions), $questionsresult);
 
@@ -401,7 +401,7 @@ final class livequiz_service_test extends \advanced_testcase {
         // Insert answers into db.
         for ($i = 0; $i < $answercount; $i++) {
             $answerid = answer::insert_answer($answers[$i]);
-            $answerswithid[] = answer::get_answer_from_id($answerid); // This ensures id's are set since set_id() is private.
+            $answerswithid[] = answer::get_answer_from_id($answerid); // This ensures ids are set since set_id() is private.
             // Simulate answers where studentid = 1 ; participationid = 1.
             $DB->insert_record('livequiz_students_answers', [
                 'student_id' => 1,
@@ -610,7 +610,7 @@ final class livequiz_service_test extends \advanced_testcase {
             foreach ($sanitizedanswers as $sanitizedanswer) {
                 $this->assertEquals($answers[0]->get_description(), $sanitizedanswer->description);
                 $this->assertEquals($answers[0]->get_explanation(), $sanitizedanswer->explanation);
-                $this->expectException(\Error::class);
+                $this->expectException(Error::class);
                 $this->expectExceptionMessage('Call to undefined method stdClass::get_correct()');
                 $sanitizedanswer->get_correct();
             }

--- a/server/moodle/mod/livequiz/tests/phpunit/outputclasstest/results_page_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/outputclasstest/results_page_test.php
@@ -22,7 +22,6 @@ use dml_exception;
 use mod_livequiz\models\answer;
 use mod_livequiz\models\livequiz;
 use mod_livequiz\models\question;
-use mod_livequiz\output\renderer;
 use mod_livequiz\output\results_page;
 use mod_livequiz\services\livequiz_services;
 use PhpXmlRpc\Exception;

--- a/server/moodle/mod/livequiz/tests/phpunit/student_answers_relation_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/student_answers_relation_test.php
@@ -24,13 +24,15 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 namespace mod_livequiz;
+use advanced_testcase;
+use dml_exception;
 use mod_livequiz\models\student_answers_relation;
 use mod_livequiz\models\answer;
 
 /**
  * student_answers_relation
  */
-final class student_answers_relation_test extends \advanced_testcase {
+final class student_answers_relation_test extends advanced_testcase {
     /**
      * Create participation test data. Used in every test.
      * @return array
@@ -46,14 +48,14 @@ final class student_answers_relation_test extends \advanced_testcase {
     /**
      * Create answer test data.
      * @return answer[]
+     * @throws dml_exception
      */
     protected function create_answer_data(): array {
-        global $DB;
         $answers = [];
         for ($i = 0; $i < 10; $i++) {
             $answer = new answer(1, 'Answer Option' . $i, 'Answer Explenation' . $i);
             $answerid = answer::insert_answer($answer);
-            $answers[] = answer::get_answer_from_id($answerid); // This ensures id's are set since set_id() is private.
+            $answers[] = answer::get_answer_from_id($answerid); // This ensures ids are set since set_id() is private.
         }
         return $answers;
     }
@@ -65,10 +67,12 @@ final class student_answers_relation_test extends \advanced_testcase {
         parent::setUp();
         $this->resetAfterTest(true);
     }
+
     /**
      * Test of insert_student_answer_relation
      * @covers \mod_livequiz\models\student_answers_relation::insert_student_answer_relation
      * @return void
+     * @throws dml_exception
      */
     public function test_insert_student_answer_relation(): void {
         $data = $this->create_test_data();
@@ -83,10 +87,12 @@ final class student_answers_relation_test extends \advanced_testcase {
         $this->assertIsNumeric($actual);
         $this->assertGreaterThan(0, $actual);
     }
+
     /**
      * Test of get_answersids_from_student_in_participation
      * @covers \mod_livequiz\models\student_quiz_relation::get_answersids_from_student_in_participation
      * @return void
+     * @throws dml_exception
      */
     public function test_get_answersids_from_student_in_participation(): void {
         $studentanswerdata = $this->create_test_data();

--- a/server/moodle/mod/livequiz/tests/phpunit/student_quiz_relation_test.php
+++ b/server/moodle/mod/livequiz/tests/phpunit/student_quiz_relation_test.php
@@ -25,15 +25,19 @@
  */
 namespace mod_livequiz;
 
+use advanced_testcase;
+use dml_exception;
+use dml_transaction_exception;
 use mod_livequiz\models\student_quiz_relation;
 
 /**
  * student_quiz_relation_test
  */
-final class student_quiz_relation_test extends \advanced_testcase {
+final class student_quiz_relation_test extends advanced_testcase {
     /**
      * Create participation test data. Used in every test.
      * @return array
+     * @throws dml_exception
      */
     protected function create_test_data(): array {
         // We need a quiz to append the participation to.
@@ -53,9 +57,12 @@ final class student_quiz_relation_test extends \advanced_testcase {
             'quizid' => $livequizid,
         ];
     }
+
     /**
      * Setup before each test.
      * @return void
+     * @throws dml_transaction_exception
+     * @throws dml_exception
      */
     protected function setUp(): void {
         parent::setUp();
@@ -63,11 +70,14 @@ final class student_quiz_relation_test extends \advanced_testcase {
         $data = $this->create_test_data();
         $actual = student_quiz_relation::insert_student_quiz_relation($data['quizid'], $data['studentid']);
     }
+
     /**
      * Test of test_append_student_to_quiz.
      * It is impossible to assert the actual table id, since it changes every time.
      * @covers \mod_livequiz\models\student_quiz_relation::append_student_to_quiz
      * @return void
+     * @throws dml_exception
+     * @throws dml_transaction_exception
      */
     public function test_append_student_to_quiz(): void {
         $data = $this->create_test_data();
@@ -76,10 +86,13 @@ final class student_quiz_relation_test extends \advanced_testcase {
         $this->assertIsNumeric($actual);
         $this->assertGreaterThan(0, $actual);
     }
+
     /**
      * Test of get_all_student_participation_for_quiz
      * @covers \mod_livequiz\models\student_quiz_relation::get_all_student_participation_for_quiz
      * @return void
+     * @throws dml_exception
+     * @throws dml_transaction_exception
      */
     public function test_get_all_student_participation_for_quiz(): void {
         $data = $this->create_test_data();


### PR DESCRIPTION
# Description
Cleans up the PHP code a bit, such that only use import is used and not \ import. 
It also adds throw tags to doc comments, where they were missing.

## Issue/fixes reference
None

## Testing
Should not be necessary

# Checks
- [ ] Updated / added tests for these changes
- [ ] PHPunit locally passed
- [ ] Codesniffer locally passed
- [ ] Behat locally passed

